### PR TITLE
Add android studio sdk location on macos

### DIFF
--- a/AndroidSdk/AndroidSdkManager.cs
+++ b/AndroidSdk/AndroidSdkManager.cs
@@ -18,6 +18,7 @@ namespace AndroidSdk
 				} :
 				new string []
 				{
+					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Android", "sdk"),
 					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Developer", "android-sdk-macosx"),
 					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Developer", "Xamarin", "android-sdk-macosx"),
 					Path.Combine("Developer", "Android", "android-sdk-macosx"),


### PR DESCRIPTION
I've added the default android studio sdk location on macOS : https://stackoverflow.com/questions/34532063/finding-android-sdk-on-mac-and-adding-to-path To fix the issue https://github.com/Clancey/vscode-comet/issues/22