### PR TITLE
Additional check for sys.boot_completed when booting emulators

### DIFF
--- a/AndroidSdk/Emulator/Emulator.cs
+++ b/AndroidSdk/Emulator/Emulator.cs
@@ -280,7 +280,8 @@ namespace AndroidSdk
 					if (process.HasExited)
 						return false;
 
-					if (adb.Shell("getprop dev.bootcomplete", Serial).Any(l => l.Contains("1")))
+					if (adb.Shell("getprop dev.bootcomplete", Serial).Any(l => l.Contains("1")) ||
+					    adb.Shell("getprop sys.boot_completed", Serial).Any(l => l.Contains("1")))
 					{
 						booted = true;
 						break;


### PR DESCRIPTION
It may be the case that `dev.bootcomplete` is not always set, so we can also check for `sys.boot_completed` to determine if the emulator is booted and ready.