### PR TITLE
Sort the cmdline-tools correctly

### DIFF
--- a/AndroidSdk.Tests/SdkManager_Tests.cs
+++ b/AndroidSdk.Tests/SdkManager_Tests.cs
@@ -50,10 +50,10 @@ namespace AndroidSdk.Tests
 			Assert.NotNull(list);
 
 			foreach (var a in list.AvailablePackages)
-				Console.WriteLine($"{a.Description}\t{a.Version}\t{a.Path}");
+				OutputHelper.WriteLine($"{a.Description}\t{a.Version}\t{a.Path}");
 
 			foreach (var a in list.InstalledPackages)
-				Console.WriteLine($"{a.Description}\t{a.Version}\t{a.Path}");
+				OutputHelper.WriteLine($"{a.Description}\t{a.Version}\t{a.Path}");
 		}
 
 		[Fact]
@@ -99,6 +99,27 @@ namespace AndroidSdk.Tests
 			var list = sdk.SdkManager.List();
 
 			Assert.NotNull(list.InstalledPackages);
+		}
+
+		[Theory]
+		[InlineData(new[] { "1.0", "2.0" }, new[] { "1.0", "2.0" })]
+		[InlineData(new[] { "2.0", "1.0" }, new[] { "1.0", "2.0" })]
+		[InlineData(new[] { "2.0", "latest" }, new[] { "2.0", "latest" })]
+		[InlineData(new[] { "1.0", "latest" }, new[] { "1.0", "latest" })]
+		[InlineData(new[] { "latest", "1.0" }, new[] { "1.0", "latest" })]
+		[InlineData(new[] { "latest", "2.0" }, new[] { "2.0", "latest" })]
+		[InlineData(new[] { "20.0", "latest" }, new[] { "20.0", "latest" })]
+		[InlineData(new[] { "11.0", "latest" }, new[] { "11.0", "latest" })]
+		[InlineData(new[] { "latest", "11.0" }, new[] { "11.0", "latest" })]
+		[InlineData(new[] { "latest", "20.0" }, new[] { "20.0", "latest" })]
+		[InlineData(new[] { "11.0", "7.0" }, new[] { "7.0", "11.0" })]
+		[InlineData(new[] { "11.0", "7.0", "latest" }, new[] { "7.0", "11.0", "latest" })]
+		public void TestDirectoryVersionSort(string[] input, string[] expected)
+		{
+			var output = input.ToList();
+			output.Sort(SdkManager.CmdLineToolsVersionComparer.Default);
+
+			Assert.Equal(expected, output);
 		}
 	}
 }

--- a/AndroidSdk/AssemblyInfo.cs
+++ b/AndroidSdk/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AndroidSdk.Tests")]

--- a/AndroidSdk/SdkManager/SdkManager.cs
+++ b/AndroidSdk/SdkManager/SdkManager.cs
@@ -64,7 +64,13 @@ namespace AndroidSdk
 
 			if (cmdlineToolsPath.Exists)
 			{
-				foreach (var dir in cmdlineToolsPath.GetDirectories())
+				// The custom comparer will make sure that the version named
+				// "latest" is treated as the latest version as well as make sure
+				// that "11.0" comes after "7.0".
+				var dirs = cmdlineToolsPath.GetDirectories()
+					.OrderBy(d => d.Name, CmdLineToolsVersionComparer.Default)
+					.ToList();
+				foreach (var dir in dirs)
 				{
 					var toolPath = new FileInfo(Path.Combine(dir.FullName, "bin", "sdkmanager" + ext));
 					if (toolPath.Exists)
@@ -631,6 +637,35 @@ namespace AndroidSdk
 			}
 
 			UpdateAll();
+		}
+
+		static string GetRelativePath(string fromPath, string toPath)
+		{
+			var fromUri = new Uri(AppendDirectorySeparatorChar(fromPath));
+			var toUri = new Uri(AppendDirectorySeparatorChar(toPath));
+			var relativeUri = fromUri.MakeRelativeUri(toUri);
+			var relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+			return relativePath;
+		}
+
+		// Append a slash only if the path is a directory and does not have a slash.
+		static string AppendDirectorySeparatorChar(string path) =>
+			Path.HasExtension(path) || path.EndsWith(Path.DirectorySeparatorChar.ToString())
+				? path
+				: path + Path.DirectorySeparatorChar;
+
+		internal class CmdLineToolsVersionComparer : IComparer<string>
+		{
+			public static CmdLineToolsVersionComparer Default { get; } = new CmdLineToolsVersionComparer();
+
+			public int Compare(string x, string y)
+			{
+				if (!Version.TryParse(x, out var vX))
+					return 1;
+				if (!Version.TryParse(y, out var vY))
+					return -1;
+				return vX.CompareTo(vY);
+			}
 		}
 	}
 }


### PR DESCRIPTION
The current sorting puts 11.0 as an older version than 7.0 because it uses string ordering.

This new change makes it order correctly and if there is a non-number version, like "latest", then it just puts that at the end.