### PR TITLE
Add more options for better control on CI

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,40 @@
+name: Run Android Emulator
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'microsoft'
+        java-version: '21'
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    - name: Install Packages
+      run: dotnet run --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
+    - name: Create AVD
+      run: dotnet run --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
+    - name: Enabling more cores
+      run: printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
+    - name: Start AVD
+      run: dotnet run --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
+    - name: Prove that it booted
+      run: |
+        dotnet run --project AndroidSdk.Tool -- device list
+        dotnet run --project AndroidSdk.Tool -- device info
+    - name: Delete AVD
+      run: dotnet run --project AndroidSdk.Tool -- avd delete -n test

--- a/AndroidSdk.Tests/Avd_Tests.cs
+++ b/AndroidSdk.Tests/Avd_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -8,6 +9,9 @@ namespace AndroidSdk.Tests
 {
 	public class AvdManager_Tests : TestsBase
 	{
+		const string TestAvdName = "TestAvd123";
+		const string TestAvdPackageId = "system-images;android-30;google_apis;x86_64";
+
 		public AvdManager_Tests(ITestOutputHelper outputHelper)
 			: base(outputHelper)
 		{ }
@@ -28,6 +32,62 @@ namespace AndroidSdk.Tests
 			var avds = sdk.AvdManager.ListAvds();
 
 			Assert.NotEmpty(avds);
+		}
+
+		[Fact]
+		public async Task InstallEmulator()
+		{
+			var sdk = GetSdk();
+			await sdk.Acquire();
+
+			// Install
+			var ok = sdk.SdkManager.Install(TestAvdPackageId);
+			Assert.True(ok);
+
+			// Assert that it installed
+			var list = sdk.SdkManager.List();
+			Assert.Contains(TestAvdPackageId, list.InstalledPackages.Select(p => p.Path));
+		}
+
+		[Fact]
+		public async Task CreateAndDeleteEmulator()
+		{
+			var sdk = GetSdk();
+			await sdk.Acquire();
+
+			// Install the right avd image
+			sdk.SdkManager.Install(TestAvdPackageId);
+
+			// Create the emulator
+			sdk.AvdManager.Create(TestAvdName, TestAvdPackageId, "pixel", force: true);
+
+			// Assert that it exists
+			var avds = sdk.AvdManager.ListAvds();
+			Assert.Contains(avds, avd => avd.Name.Equals(TestAvdName, StringComparison.OrdinalIgnoreCase));
+
+			// Delete the emulator
+			sdk.AvdManager.Delete(TestAvdName);
+		}
+
+		[Fact]
+		public async Task CreateAndDeleteEmulatorWithAbi()
+		{
+			var sdk = GetSdk();
+			await sdk.Acquire();
+
+			// Install the right avd image
+			sdk.SdkManager.Install(TestAvdPackageId);
+
+			// Create the emulator
+			var options = new AvdManager.AvdCreateOptions { Device = "pixel", Force = true, Abi = "google_apis/x86_64" };
+			sdk.AvdManager.Create(TestAvdName, TestAvdPackageId, options);
+
+			// Assert that it exists
+			var avds = sdk.AvdManager.ListAvds();
+			Assert.Contains(avds, avd => avd.Name.Equals(TestAvdName, StringComparison.OrdinalIgnoreCase));
+
+			// Delete the emulator
+			sdk.AvdManager.Delete(TestAvdName);
 		}
 	}
 }

--- a/AndroidSdk.Tests/Emulator_Tests.cs
+++ b/AndroidSdk.Tests/Emulator_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.SymbolStore;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,52 +10,61 @@ namespace AndroidSdk.Tests
 {
 	public class Emulator_Tests : TestsBase
 	{
+		const string TestEmulatorName = "TestEmu123";
+		const string TestAvdImagePackageId = "system-images;android-31;google_apis;x86_64";
+
 		public Emulator_Tests(ITestOutputHelper outputHelper)
 			: base(outputHelper)
 		{ }
 
-		//[Fact]
-		public void CreateAndStartAndStopEmulator()
-		{
-			var sdk = GetSdk();
-			sdk.Acquire();
+		[Fact]
+		public Task CreateAndStartAndStopEmulator() =>
+			CreateTestEmulator(sdk =>
+			{
+				// Start the emulator
+				var emulatorInstance = sdk.Emulator.Start(TestEmulatorName);
 
-			var avdImagePackageId = "system-images;android-31;google_apis;x86_64";
+				// Wait for the boot
+				var booted = emulatorInstance.WaitForBootComplete();
+				Assert.True(booted);
 
-			// Install the right avd image
-			sdk.SdkManager.Install(avdImagePackageId);
+				// Assert that the emulator is valid
+				Assert.NotEmpty(emulatorInstance.Serial);
+				Assert.Equal(TestEmulatorName, emulatorInstance.AvdName);
 
-			sdk.AvdManager.Create("TestEmu123", avdImagePackageId, "pixel", force: true);
-
-			var emulatorInstance = sdk.Emulator.Start("TestEmu123");
-
-			var booted = emulatorInstance.WaitForBootComplete();
-
-			Assert.True(booted);
-
-			var shutdown = emulatorInstance.Shutdown();
-
-			Assert.True(shutdown);
-		}
+				// Shutdown the emulator
+				var shutdown = emulatorInstance.Shutdown();
+				Assert.True(shutdown);
+			});
 
 		[Fact]
-		public async Task CreateEmulator()
-		{
-			var sdk = GetSdk();
-			await sdk.Acquire();
+		public Task CreateAndStartAndStopHeadlessEmulatorWithOptions() =>
+			CreateTestEmulator(sdk =>
+			{
+				// Start the emulator
+				var options = new Emulator.EmulatorStartOptions
+				{
+					Port = 5554,
+					NoWindow = true,
+					Gpu = "swiftshader_indirect",
+					NoSnapshot = true,
+					NoAudio = true,
+					NoBootAnim = true
+				};
+				var emulatorInstance = sdk.Emulator.Start(TestEmulatorName, options);
 
-			var avdImagePackageId = "system-images;android-30;google_apis;x86_64";
+				// Wait for the boot
+				var booted = emulatorInstance.WaitForBootComplete();
+				Assert.True(booted);
 
-			// Install the right avd image
-			sdk.SdkManager.Install(avdImagePackageId);
+				// Assert that the emulator is valid
+				Assert.Equal("emulator-5554", emulatorInstance.Serial);
+				Assert.Equal(TestEmulatorName, emulatorInstance.AvdName);
 
-			sdk.AvdManager.Create("TestEmu123", avdImagePackageId, "pixel", force: true);
-
-
-			var avds = sdk.AvdManager.ListAvds();
-
-			Assert.Contains(avds, avd => avd.Name.Equals("TestEmu123", StringComparison.OrdinalIgnoreCase));
-		}
+				// Shutdown the emulator
+				var shutdown = emulatorInstance.Shutdown();
+				Assert.True(shutdown);
+			});
 
 		[Fact]
 		public async Task ListAvds()
@@ -65,6 +75,31 @@ namespace AndroidSdk.Tests
 			var avds = sdk.Emulator.ListAvds();
 
 			Assert.NotNull(avds);
+		}
+
+		Task CreateTestEmulator(Action<AndroidSdkManager> test) =>
+			CreateTestEmulator(sdk =>
+			{
+				test(sdk);
+				return Task.CompletedTask;
+			});
+
+		async Task CreateTestEmulator(Func<AndroidSdkManager, Task> test)
+		{
+			var sdk = GetSdk();
+			await sdk.Acquire();
+
+			// Install the right avd image
+			sdk.SdkManager.Install(TestAvdImagePackageId);
+
+			// Create the emulator instance
+			sdk.AvdManager.Create(TestEmulatorName, TestAvdImagePackageId, "pixel", force: true);
+
+			// Run the actual test
+			await test(sdk);
+
+			// Delete the emulator
+			sdk.AvdManager.Delete(TestEmulatorName);
 		}
 	}
 }

--- a/AndroidSdk.Tool/AndroidSdk.Tool.csproj
+++ b/AndroidSdk.Tool/AndroidSdk.Tool.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<AssemblyName>android</AssemblyName>
 		<PackAsTool>true</PackAsTool>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFramework>net7.0</TargetFramework>
 		<ToolCommandName>android</ToolCommandName>
 		<RollForward>Major</RollForward>
 	</PropertyGroup>

--- a/AndroidSdk.Tool/AvdCreateCommand.cs
+++ b/AndroidSdk.Tool/AvdCreateCommand.cs
@@ -39,9 +39,17 @@ namespace AndroidSdk.Tool
 		[Description("Size of SDCard to create in megabytes")]
 		[CommandOption("--sdcard-size")]
 		public int? SdCardSizeMb { get; set; }
+		
+		[Description("The ABI to use for the AVD (Auto-selects if there is only one ABI)")]
+		[CommandOption("-a|--abi")]
+		public string Abi { get; set; }
+		
+		[Description("The name of a skin to use with this device.")]
+		[CommandOption("--skin")]
+		public string Skin { get; set; }
 
 		[Description("Force the creation of the AVD")]
-		[CommandOption("--force")]
+		[CommandOption("-f|--force")]
 		public bool Force { get; set; }
 
 		public override ValidationResult Validate()
@@ -64,14 +72,26 @@ namespace AndroidSdk.Tool
 			{
 				var avd = new AvdManager(settings?.Home);
 
+				string sdcard = null;
+				if (!string.IsNullOrEmpty(settings.SdCardPath))
+					sdcard = settings.SdCardPath;
+				else if (settings.SdCardSizeMb.HasValue)
+					sdcard = settings.SdCardSizeMb.ToString() + "MB";
+
+				var options = new AvdManager.AvdCreateOptions
+				{
+					Device = settings.DeviceId,
+					Path = settings.Path,
+					Force = settings.Force,
+					SdCardPathOrSize = sdcard,
+					Abi = settings.Abi,
+					Skin = settings.Skin
+				};
+
 				avd.Create(
 					settings.Name,
 					settings.SdkId,
-					settings.DeviceId,
-					settings.Path,
-					settings.Force,
-					settings.SdCardPath,
-					settings.SdCardSizeMb.HasValue ? (settings.SdCardSizeMb.ToString() + "MB") : (string)null);
+					options);
 			}
 			catch (SdkToolFailedExitException sdkEx)
 			{

--- a/AndroidSdk.Tool/Program.cs
+++ b/AndroidSdk.Tool/Program.cs
@@ -16,8 +16,7 @@ namespace AndroidSdk.Tool
 			var app = new CommandApp();
 			app.Configure(config =>
 			{
-				config
-				.AddBranch("sdk", sdkBranch =>
+				config.AddBranch("sdk", sdkBranch =>
 				{
 					sdkBranch.AddCommand<SdkListCommand>("list")
 						.WithDescription("Lists Android SDK packages")

--- a/AndroidSdk/AssemblyInfo.cs
+++ b/AndroidSdk/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AndroidSdk.Tests")]
+[assembly: InternalsVisibleTo("android")]

--- a/AndroidSdk/AvdManager/AvdCreateOptions.cs
+++ b/AndroidSdk/AvdManager/AvdCreateOptions.cs
@@ -1,0 +1,20 @@
+﻿namespace AndroidSdk
+{
+	public partial class AvdManager
+	{
+		public class AvdCreateOptions
+		{
+			public string Device { get; set; }
+
+			public string Path { get; set; }
+
+			public string SdCardPathOrSize { get; set; }
+
+			public bool Force { get; set; }
+
+			public string Abi { get; set; }
+
+			public string Skin { get; set; }
+		}
+	}
+}

--- a/AndroidSdk/Emulator/Emulator.cs
+++ b/AndroidSdk/Emulator/Emulator.cs
@@ -123,6 +123,15 @@ namespace AndroidSdk
 
 			if (options.Engine.HasValue)
 				builder.Append($"-engine {options.Engine.Value.ToString().ToLowerInvariant()}");
+			
+			if (!string.IsNullOrEmpty(options.Gpu))
+				builder.Append($"-gpu {options.Gpu.ToLowerInvariant()}");
+
+			if (options.NoWindow)
+				builder.Append("-no-window");
+
+			if (options.NoAudio)
+				builder.Append("-no-audio");
 
 			if (options.NoJni)
 				builder.Append("-no-jni");
@@ -225,8 +234,13 @@ namespace AndroidSdk
 			}
 
 			public IEnumerable<string> GetStandardOutput()
-				=> result?.StandardOutput ?? new List<string>();
+				=> process.StandardOutput ?? new List<string>();
+			
+			public IEnumerable<string> GetStandardError()
+				=> process.StandardError ?? new List<string>();
 
+			public IEnumerable<string> GetOutput()
+				=> process.Output ?? new List<string>();
 
 			public bool WaitForBootComplete()
 				=> WaitForBootComplete(TimeSpan.Zero);

--- a/AndroidSdk/Emulator/EmulatorStartOptions.cs
+++ b/AndroidSdk/Emulator/EmulatorStartOptions.cs
@@ -21,46 +21,14 @@ namespace AndroidSdk
 			public string CameraBack
 			{
 				get => cameraBack;
-				set
-				{
-					var v = value.ToLowerInvariant();
-
-					if (v != "emulated" && v != "none" && !v.StartsWith("webcam"))
-						throw new ArgumentOutOfRangeException(nameof(CameraBack), cameraArgumentMessage);
-
-					if (v.StartsWith("webcam"))
-					{
-						var n = v.Substring(6);
-
-						if (!int.TryParse(n, out _))
-							throw new ArgumentOutOfRangeException(nameof(CameraBack), cameraArgumentMessage);
-					}
-
-					cameraBack = v;
-				}
+				set => cameraBack = ValidateCamera(nameof(CameraBack), value);
 			}
 
 			string cameraFront = null;
 			public string CameraFront
 			{
 				get => cameraFront;
-				set
-				{
-					var v = value.ToLowerInvariant();
-
-					if (v != "emulated" && v != "none" && !v.StartsWith("webcam"))
-						throw new ArgumentOutOfRangeException(nameof(CameraBack), cameraArgumentMessage);
-
-					if (v.StartsWith("webcam"))
-					{
-						var n = v.Substring(6);
-
-						if (!int.TryParse(n, out _))
-							throw new ArgumentOutOfRangeException(nameof(CameraBack), cameraArgumentMessage);
-					}
-
-					cameraFront = v;
-				}
+				set => cameraFront = ValidateCamera(nameof(CameraFront), value);
 			}
 
 			public int? MemoryMegabytes { get; set; }
@@ -101,7 +69,11 @@ namespace AndroidSdk
 
 			public bool NoAccel { get; set; }
 
+			public bool NoWindow { get; set; }
+
 			public bool NoJni { get; set; }
+
+			public bool NoAudio { get; set; }
 
 			public EmulatorSeLinux? SeLinux { get; set; }
 
@@ -112,6 +84,29 @@ namespace AndroidSdk
 			public EmulatorScreenMode? Screen { get; set; }
 
 			public string[] ExtraArgs { get; set; }
+
+			internal static string ValidateCamera(string paramName, string value)
+			{
+				if (value is null)
+				{
+					return null;
+				}
+
+				var v = value.ToLowerInvariant();
+
+				if (v != "emulated" && v != "none" && !v.StartsWith("webcam"))
+					throw new ArgumentOutOfRangeException(paramName, cameraArgumentMessage);
+
+				if (v.StartsWith("webcam"))
+				{
+					var n = v.Substring(6);
+
+					if (!int.TryParse(n, out _))
+						throw new ArgumentOutOfRangeException(paramName, cameraArgumentMessage);
+				}
+
+				return v;
+			}
 		}
 
 		public enum EmulatorScreenMode

--- a/AndroidSdk/SdkManager/SdkManager.cs
+++ b/AndroidSdk/SdkManager/SdkManager.cs
@@ -571,6 +571,7 @@ namespace AndroidSdk
 			proc.BeginOutputReadLine();
 			proc.BeginErrorReadLine();
 
+			// continuously send "y" to accept any licenses
 			while (!proc.HasExited)
 			{
 				Thread.Sleep(250);


### PR DESCRIPTION
Add 2 new flags to `avd create`:

* `--skin` for a nice look
* `--abi` to control which ABI is selected when there are multiple for a single image.

Add several flags for `avd start`:

* `--no-snapshot-load`
* `--no-snapshot-save`
* `--camera-back`
* `--camera-front`
* `--port` to control ports for predictability on CI
* `--screen` for controlling touch support
* `--engine` 
* `--accel-mode`
* `--no-accel`
* `--no-boot-anim` for faster boots
* `--no-window` for headless scenarios
* `--no-audio` for some CI machines with missing libraries
* `--gpu` to pick a different system on nested hypervisors on CI
* `--no-jni`
* `--verbose` for extra details