### PR TITLE
Update the TFMs for the library, tests and tools

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - uses: actions/setup-java@v4
       with:
         distribution: 'microsoft'

--- a/AndroidSdk.Adbd.Tests/AndroidSdk.Adbd.Tests.csproj
+++ b/AndroidSdk.Adbd.Tests/AndroidSdk.Adbd.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants Condition="'$(CI)' == 'true'">$(DefineConstants);IS_ON_CI</DefineConstants>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/AndroidSdk.Adbd/AndroidSdk.Adbd.csproj
+++ b/AndroidSdk.Adbd/AndroidSdk.Adbd.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/AndroidSdk.Tests/AndroidSdk.Tests.csproj
+++ b/AndroidSdk.Tests/AndroidSdk.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants Condition="'$(CI)' == 'true'">$(DefineConstants);IS_ON_CI</DefineConstants>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/AndroidSdk.Tool/AndroidSdk.Tool.csproj
+++ b/AndroidSdk.Tool/AndroidSdk.Tool.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<AssemblyName>android</AssemblyName>
 		<PackAsTool>true</PackAsTool>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<ToolCommandName>android</ToolCommandName>
 		<RollForward>Major</RollForward>
 	</PropertyGroup>

--- a/AndroidSdk/AndroidSdk.csproj
+++ b/AndroidSdk/AndroidSdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 

--- a/AndroidSdk/AssemblyInfo.cs
+++ b/AndroidSdk/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AndroidSdk.Tests")]
+[assembly: InternalsVisibleTo("AndroidSdk.Adbd.Tests")]
 [assembly: InternalsVisibleTo("android")]


### PR DESCRIPTION
Currently the TFMs were net7 which is not in support, so I dropped down to the net6.0 LTS and made the tests use the latest LTS net8.0.