### PR TITLE
Build main and PRs not all branches

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -3,6 +3,7 @@ name: Build and Publish
 on:
   pull_request:
   push:
+    branches: [ main ]
   release:
     types: [published]
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -3,6 +3,7 @@ name: Run Android Emulator
 on:
   pull_request:
   push:
+    branches: [ main ]
 
 jobs:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   pull_request:
   push:
+    branches: [ main ]
 
 permissions:
   checks: write


### PR DESCRIPTION
When making a PR locally, there is a double build happening and this is just a waste.