### PR TITLE
Stop code signing / creating tool shim

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,20 +26,20 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
     - name: Install Packages
-      run: dotnet run --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
+      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
     - name: Create AVD
-      run: dotnet run --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
+      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
     - name: Enabling more cores
       run: printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
     - name: Start AVD
-      run: dotnet run --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
+      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted
       run: |
-        dotnet run --project AndroidSdk.Tool -- device list
-        dotnet run --project AndroidSdk.Tool -- device info
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- device list
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- device info
     - name: Install an app
-      run: dotnet run --project AndroidSdk.Tool -- device install --package AndroidSdk.Tests/testdata/com.companyname.mauiapp12345-Signed.apk
+      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- device install --package AndroidSdk.Tests/testdata/com.companyname.mauiapp12345-Signed.apk
     - name: Uninstall an app
-      run: dotnet run --project AndroidSdk.Tool -- device uninstall --package com.companyname.mauiapp12345
+      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- device uninstall --package com.companyname.mauiapp12345
     - name: Delete AVD
-      run: dotnet run --project AndroidSdk.Tool -- avd delete -n test
+      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd delete -n test

--- a/AndroidSdk.Adbd.Tests/AndroidSdk.Adbd.Tests.csproj
+++ b/AndroidSdk.Adbd.Tests/AndroidSdk.Adbd.Tests.csproj
@@ -11,13 +11,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/AndroidSdk.Adbd/AndroidSdk.Adbd.csproj
+++ b/AndroidSdk.Adbd/AndroidSdk.Adbd.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/AndroidSdk.Tests/AndroidSdk.Tests.csproj
+++ b/AndroidSdk.Tests/AndroidSdk.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/AndroidSdk.Tool/AndroidSdk.Tool.csproj
+++ b/AndroidSdk.Tool/AndroidSdk.Tool.csproj
@@ -23,7 +23,7 @@
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<DebugType>portable</DebugType>
-		<PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</PackAsToolShimRuntimeIdentifiers>
+		<!--<PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</PackAsToolShimRuntimeIdentifiers>-->
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' Or '$(TF_BUILD)' == 'true'">

--- a/AndroidSdk.Tool/AndroidSdk.Tool.csproj
+++ b/AndroidSdk.Tool/AndroidSdk.Tool.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<AssemblyName>android</AssemblyName>
 		<PackAsTool>true</PackAsTool>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 		<ToolCommandName>android</ToolCommandName>
 		<RollForward>Major</RollForward>
 	</PropertyGroup>
@@ -31,17 +31,17 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
-		<PackageReference Include="Spectre.Console" Version="0.46.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+		<PackageReference Include="Spectre.Console" Version="0.49.1" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\AndroidSdk\AndroidSdk.csproj" />
 	</ItemGroup>
 	 
-	<PropertyGroup>
+	<!--<PropertyGroup>
 		<SigningTimestampServer>http://timestamp.entrust.net/TSS/RFC3161sha2TS</SigningTimestampServer>
 		<SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe</SignToolPath>
 	</PropertyGroup>
@@ -56,6 +56,6 @@
 
 	<Target Name="NugetSignAfterPack" AfterTargets="Pack" Condition="'$(SigningCertificatePfxFile)' != ''">
 		<Exec Command="nuget sign $(PackageOutputAbsolutePath)\*.nupkg -CertificatePath $(SigningCertificatePfxFile) -Timestamper $(SigningTimestampServer)" />
-	</Target>
+	</Target>-->
 
 </Project>

--- a/AndroidSdk/AndroidSdk.csproj
+++ b/AndroidSdk/AndroidSdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
@@ -26,6 +26,6 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Seems apple does not like things if you run a tool via shim.

I no longer am maintaining code signing certificates as they have become prohibitively expensive.

So, this stops generating shims and trying to code sign with a now expired cert.