### PR TITLE
Add more Android SDK known paths

### DIFF
--- a/AndroidSdk/SdkLocator.cs
+++ b/AndroidSdk/SdkLocator.cs
@@ -20,6 +20,9 @@ public class SdkLocator : PathLocator
 			new [] {
 				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Android", "android-sdk"),
 				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Android", "Sdk"),
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "android-sdk"),
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Android"),
 			} :
 			new []
 			{


### PR DESCRIPTION
The MAUI docs suggest putting the AndroidSdk in `$env:LOCALAPPDATA\Android\Sdk` but we don't expect that in this tool.

This adds a couple more potentially known paths to detect.