### PR TITLE
Better JDK resolution

### DIFF
--- a/AndroidSdk.sln
+++ b/AndroidSdk.sln
@@ -13,6 +13,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AndroidSdk.Adbd", "AndroidS
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AndroidSdk.Adbd.Tests", "AndroidSdk.Adbd.Tests\AndroidSdk.Adbd.Tests.csproj", "{61262BFD-2765-4574-A83C-87474C89D38A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{5A3A2587-3845-4F6F-9463-D5D35CFECE62}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-publish.yml = .github\workflows\build-publish.yml
+		.github\workflows\run.yml = .github\workflows\run.yml
+		.github\workflows\test.yml = .github\workflows\test.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/AndroidSdk/JdkInfo.cs
+++ b/AndroidSdk/JdkInfo.cs
@@ -5,7 +5,7 @@ namespace AndroidSdk
 {
 	public class JdkInfo
 	{
-		public JdkInfo(string javaCFile, string version)
+		public JdkInfo(string javaCFile, string version, bool setByEnvironmentVariable = false)
 		{
 			var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
@@ -13,12 +13,15 @@ namespace AndroidSdk
 			Home = new DirectoryInfo(Path.Combine(JavaC.Directory.FullName, ".."));
 			Java = new FileInfo(Path.Combine(Home.FullName, "bin", "java" + (isWindows ? ".exe" : "")));
 			Version = version;
+			SetByEnvironmentVariable = setByEnvironmentVariable;
 		}
 
 		public FileInfo JavaC { get; private set; }
 		public FileInfo Java { get; private set; }
 
 		public DirectoryInfo Home { get; private set; }
+
+		public bool SetByEnvironmentVariable { get; private set; } = false;
 
 		public string Version { get; set; }
 	}


### PR DESCRIPTION
First of all, fixed a bug where we didn't check the Program Files\Microsoft\jdk-* folders recursively, so we would never actually find  java.exe as we searched top level dir only.

Next, we also order the results with some opinions (since many consumers may just grab the first result):
1. Prefer the JDK paths which were set as the environment variable (this shows intent to override anything else)
2. Order by highest to lowest JDK version
3. Ignore file path casing when grouping duplicate resolved paths


Also: Include pipeline yaml in the sln explorer