### PR TITLE
More JDK/Android SDK locator paths

### DIFF
--- a/AndroidSdk.Tests/MonoDroidSdkLocator_Tests.cs
+++ b/AndroidSdk.Tests/MonoDroidSdkLocator_Tests.cs
@@ -1,0 +1,25 @@
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AndroidSdk.Tests;
+
+public class MonoDroidSdkLocator_Tests : TestsBase
+{
+	public MonoDroidSdkLocator_Tests(ITestOutputHelper outputHelper)
+		: base(outputHelper)
+	{
+	}
+
+	[Fact]
+	public void LocatePaths()
+	{
+		var location
+			= OperatingSystem.IsWindows()
+				? MonoDroidSdkLocator.ReadRegistry()
+				: MonoDroidSdkLocator.ReadConfigFile();
+
+		Assert.NotNull(location.JavaJdkPath);
+		Assert.NotNull(location.AndroidSdkPath);
+	}
+}

--- a/AndroidSdk/AndroidSdk.csproj
+++ b/AndroidSdk/AndroidSdk.csproj
@@ -27,5 +27,6 @@
 	
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+	  <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
 	</ItemGroup>
 </Project>

--- a/AndroidSdk/JdkLocator.cs
+++ b/AndroidSdk/JdkLocator.cs
@@ -36,7 +36,7 @@ namespace AndroidSdk
 				SearchDirectoryForJdks(paths, specificHome, true);
 			}
 
-			if (OperatingSystem.IsWindows()) {
+			if (IsWindows) {
 				// Try the registry entries known by the Xamarin SDK
 				var registryConfig = MonoDroidSdkLocator.ReadRegistry();
 				if (!string.IsNullOrEmpty(registryConfig.JavaJdkPath))

--- a/AndroidSdk/JdkLocator.cs
+++ b/AndroidSdk/JdkLocator.cs
@@ -36,6 +36,20 @@ namespace AndroidSdk
 				SearchDirectoryForJdks(paths, specificHome, true);
 			}
 
+			if (OperatingSystem.IsWindows()) {
+				// Try the registry entries known by the Xamarin SDK
+				var registryConfig = MonoDroidSdkLocator.ReadRegistry();
+				if (!string.IsNullOrEmpty(registryConfig.JavaJdkPath))
+					SearchDirectoryForJdks(paths, registryConfig.JavaJdkPath, true);
+			}
+			else
+			{
+				// Try the monodroid-config.xml file known by the Xamarin SDK
+				var monodroidConfig = MonoDroidSdkLocator.ReadConfigFile();
+				if (!string.IsNullOrEmpty(monodroidConfig.JavaJdkPath))
+					SearchDirectoryForJdks(paths, monodroidConfig.JavaJdkPath, true);
+			}
+
 			if (IsWindows)
 			{
 				SearchDirectoryForJdks(paths,

--- a/AndroidSdk/MonoDroidSdkLocator.cs
+++ b/AndroidSdk/MonoDroidSdkLocator.cs
@@ -35,7 +35,7 @@ public static class MonoDroidSdkLocator
 			
 			return new MonoDroidSdkLocation(
 				doc.SelectSingleNode("//monodroid/android-sdk")?.Attributes?["path"]?.Value,
-				doc?.SelectSingleNode("//monodroid/java-sdk")?.Attributes?["path"]?.Value);
+				doc.SelectSingleNode("//monodroid/java-sdk")?.Attributes?["path"]?.Value);
 		}
 
 		return new MonoDroidSdkLocation();;

--- a/AndroidSdk/MonoDroidSdkLocator.cs
+++ b/AndroidSdk/MonoDroidSdkLocator.cs
@@ -1,0 +1,146 @@
+
+using System;
+using System.IO;
+using Microsoft.Win32;
+
+public class MonoDroidSdkLocation
+{
+	public MonoDroidSdkLocation(string? androidSdkPath = null, string? javaJdkPath = null)
+	{
+		AndroidSdkPath = androidSdkPath;
+		JavaJdkPath = javaJdkPath;
+	}
+
+	public readonly string? AndroidSdkPath;
+	public readonly string? JavaJdkPath;
+}
+
+public static class MonoDroidSdkLocator
+{
+	/*
+	<?xml version="1.0" encoding="utf-8"?>
+	<monodroid>
+	<android-sdk path="/Users/redth/Library/Developer/Xamarin/android-sdk-macosx" />
+	<java-sdk path="/Library/Java/JavaVirtualMachines/microsoft-11.jdk/Contents/Home" />
+	</monodroid>%  
+	*/
+	public static MonoDroidSdkLocation ReadConfigFile()
+	{
+		// Load the XML file
+		var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "xbuild", "monodroid-config.xml");
+		if (File.Exists(path))
+		{
+			var doc = new System.Xml.XmlDocument();
+			doc.Load(path);
+			
+			return new MonoDroidSdkLocation(
+				doc.SelectSingleNode("//monodroid/android-sdk")?.Attributes?["path"]?.Value,
+				doc?.SelectSingleNode("//monodroid/java-sdk")?.Attributes?["path"]?.Value);
+		}
+
+		return new MonoDroidSdkLocation();;
+	}
+
+	public static void WriteConfigFile(MonoDroidSdkLocation location)
+	{
+		// Load the XML file
+		var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "xbuild", "monodroid-config.xml");
+		if (File.Exists(path))
+		{
+			var doc = new System.Xml.XmlDocument();
+			doc.Load(path);
+
+			var monodroidNode = doc.SelectSingleNode("//monodroid");
+			if (monodroidNode == null)
+			{
+				monodroidNode = doc.CreateElement("monodroid");
+				doc.AppendChild(monodroidNode);
+			}
+			
+			if (!string.IsNullOrEmpty(location.AndroidSdkPath))
+			{
+				var androidSdkNode = monodroidNode.SelectSingleNode("//monodroid/android-sdk");
+				if (androidSdkNode == null)
+				{
+					androidSdkNode = doc.CreateElement("android-sdk");
+					monodroidNode.AppendChild(androidSdkNode);
+				}
+				if (androidSdkNode.Attributes["path"] == null)
+					androidSdkNode.Attributes.Append(doc.CreateAttribute("path"));
+				androidSdkNode.Attributes["path"].Value = location.AndroidSdkPath;
+			}
+			
+			if (!string.IsNullOrEmpty(location.JavaJdkPath))
+			{
+				var javaSdkNode = doc.SelectSingleNode("//monodroid/java-sdk");
+				if (javaSdkNode == null)
+				{
+					javaSdkNode = doc.CreateElement("java-sdk");
+					monodroidNode.AppendChild(javaSdkNode);
+				}
+				if (javaSdkNode.Attributes["path"] == null)
+					javaSdkNode.Attributes.Append(doc.CreateAttribute("path"));
+				javaSdkNode.Attributes["path"].Value = location.JavaJdkPath;
+			}
+
+			doc.Save(path);
+		}
+	}
+
+	public static MonoDroidSdkLocation ReadRegistry()
+	{
+		if (!OperatingSystem.IsWindows())
+			return new MonoDroidSdkLocation();
+
+		// Define the registry key path
+		string[] registryPaths = [ 
+			"SOFTWARE\\Novell\\Mono for Android",
+			"SOFTWARE\\Xamarin\\MonoAndroid"
+		];
+
+		string? androidSdkPath = null;
+		string? javaJdkPath = null;
+
+		foreach (var registryPath in registryPaths)
+		{
+			// Open the registry key under HKCU (HKEY_CURRENT_USER)
+			using var key = Registry.CurrentUser.OpenSubKey(registryPath);
+			
+			// Only set if we didn't get one yet
+			if (string.IsNullOrEmpty(androidSdkPath))
+				androidSdkPath = key?.GetValue("AndroidSdkDirectory") as string;
+			if (string.IsNullOrEmpty(javaJdkPath))
+				javaJdkPath = key?.GetValue("JavaSdkDirectory") as string;
+		}
+		
+		return new MonoDroidSdkLocation(androidSdkPath, javaJdkPath);
+	}
+
+	public static void WriteRegistry(MonoDroidSdkLocation location)
+	{
+		if (!OperatingSystem.IsWindows())
+			return;
+
+		if (string.IsNullOrEmpty(location.AndroidSdkPath) && string.IsNullOrEmpty(location.JavaJdkPath))
+			return;
+
+		// Define the registry key path
+		string[] registryPaths = [ 
+			"SOFTWARE\\Novell\\Mono for Android",
+			"SOFTWARE\\Xamarin\\MonoAndroid"
+		];
+
+		foreach (var registryPath in registryPaths)
+		{
+			// Open or create the registry key under HKCU (HKEY_CURRENT_USER)
+			using var key = Registry.CurrentUser.OpenSubKey(registryPath)
+				?? Registry.CurrentUser.CreateSubKey(registryPath);
+
+			// Only set if we didn't get one yet
+			if (!string.IsNullOrEmpty(location.AndroidSdkPath))
+				key?.SetValue("AndroidSdkDirectory", location.AndroidSdkPath);
+			if (!string.IsNullOrEmpty(location.JavaJdkPath))
+				key?.SetValue("JavaSdkDirectory", location.JavaJdkPath);
+		}
+	}
+}

--- a/AndroidSdk/MonoDroidSdkLocator.cs
+++ b/AndroidSdk/MonoDroidSdkLocator.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.Win32;
 
 public class MonoDroidSdkLocation
@@ -17,6 +18,9 @@ public class MonoDroidSdkLocation
 
 public static class MonoDroidSdkLocator
 {
+	internal static bool IsWindows
+		=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
 	/*
 	<?xml version="1.0" encoding="utf-8"?>
 	<monodroid>
@@ -89,7 +93,7 @@ public static class MonoDroidSdkLocator
 
 	public static MonoDroidSdkLocation ReadRegistry()
 	{
-		if (!OperatingSystem.IsWindows())
+		if (!IsWindows)
 			return new MonoDroidSdkLocation();
 
 		// Define the registry key path
@@ -118,7 +122,7 @@ public static class MonoDroidSdkLocator
 
 	public static void WriteRegistry(MonoDroidSdkLocation location)
 	{
-		if (!OperatingSystem.IsWindows())
+		if (!IsWindows)
 			return;
 
 		if (string.IsNullOrEmpty(location.AndroidSdkPath) && string.IsNullOrEmpty(location.JavaJdkPath))

--- a/AndroidSdk/SdkLocator.cs
+++ b/AndroidSdk/SdkLocator.cs
@@ -8,11 +8,14 @@ namespace AndroidSdk;
 
 public class SdkLocator : PathLocator
 {
+	protected bool IsWindows
+			=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
 	public override string[] PreferredPaths()
 	{
 		var paths = new List<string>();
 
-		if (OperatingSystem.IsWindows()) {
+		if (IsWindows) {
 			// Try the registry entries known by the Xamarin SDK
 			var registryConfig = MonoDroidSdkLocator.ReadRegistry();
 			if (!string.IsNullOrEmpty(registryConfig.AndroidSdkPath))

--- a/AndroidSdk/SdkLocator.cs
+++ b/AndroidSdk/SdkLocator.cs
@@ -9,26 +9,52 @@ namespace AndroidSdk;
 public class SdkLocator : PathLocator
 {
 	public override string[] PreferredPaths()
-		=> new[]
+	{
+		var paths = new List<string>();
+
+		if (OperatingSystem.IsWindows()) {
+			// Try the registry entries known by the Xamarin SDK
+			var registryConfig = MonoDroidSdkLocator.ReadRegistry();
+			if (!string.IsNullOrEmpty(registryConfig.AndroidSdkPath))
+				paths.Add(registryConfig.AndroidSdkPath);
+		}
+		else
 		{
-			Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT"),
-			Environment.GetEnvironmentVariable("ANDROID_HOME")
-		};
+			// Try the monodroid-config.xml file known by the Xamarin SDK
+			var monodroidConfig = MonoDroidSdkLocator.ReadConfigFile();
+			if (!string.IsNullOrEmpty(monodroidConfig.AndroidSdkPath))
+				paths.Add(monodroidConfig.AndroidSdkPath);
+		}
+
+		var androidSdkRoot = Environment.GetEnvironmentVariable("ANDROID_SDK_ROOT");
+		if (!string.IsNullOrEmpty(androidSdkRoot))
+			paths.Add(androidSdkRoot);
+
+		var androidHome = Environment.GetEnvironmentVariable("ANDROID_HOME");
+		if (!string.IsNullOrEmpty(androidHome))
+			paths.Add(androidHome);
+
+		return paths.ToArray();
+	}
 
 	public override string[] AdditionalPaths()
 		=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
-			new [] {
-				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Android", "android-sdk"),
-				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
-				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Android", "Sdk"),
-				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "android-sdk"),
-				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Android"),
-			} :
-			new []
-			{
-				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Developer", "android-sdk-macosx"),
-				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Developer", "Xamarin", "android-sdk-macosx"),
-				Path.Combine("Developer", "Android", "android-sdk-macosx"),
-				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Android", "sdk"),
-			};
+		[
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Android", "android-sdk"),
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Android", "Sdk"),
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "android-sdk"),
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Android"),
+		] :
+		[
+			// Xamarin.Android seems to check this path first
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Android", "sdk"),
+
+			// These are other known paths
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Developer", "android-sdk-macosx"),
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Developer", "Xamarin", "android-sdk-macosx"),
+			Path.Combine("Developer", "Android", "android-sdk-macosx"),
+		];
+
+	
 }


### PR DESCRIPTION
This adds some lookups based on what the .NET Android SDK/Workload currently uses.

On windows, there's a couple of registry keys, and on macOS/Linux there's a config xml file potentially containing this information.