### PR TITLE
Fix JDK locator Library path on mac

### DIFF
--- a/AndroidSdk/JdkLocator.cs
+++ b/AndroidSdk/JdkLocator.cs
@@ -73,16 +73,13 @@ namespace AndroidSdk
 			}
 			else if (IsMac)
 			{
-				var ms11Dir = Path.Combine("/Library", "Java", "JavaVirtualMachines", "microsoft-11.jdk", "Contents", "Home");
-				SearchDirectoryForJdks(paths, ms11Dir, true);
-
 				var msDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Developer", "Xamarin", "jdk");
 				SearchDirectoryForJdks(paths, msDir, true);
 
 				// /Library/Java/JavaVirtualMachines/
 				try
 				{
-					var javaVmDir = Path.Combine("Library", "Java", "JavaVirtualMachines");
+					var javaVmDir = Path.Combine("/", "Library", "Java", "JavaVirtualMachines");
 
 					if (Directory.Exists(javaVmDir))
 					{


### PR DESCRIPTION
The java directory was resolving to `Library/...` instead of `/Library/...` so it never found any microsoft JVM's, this fixes it so the path is scanned correctly.

Also removed the explicit check for the old JDK 11 (it will be picked up by this fix anyway if it's there).