### PR TITLE
Add jdk and sdk dotnet-prefer commands

### DIFF
--- a/AndroidSdk.Tool/AndroidSdk.Tool.csproj
+++ b/AndroidSdk.Tool/AndroidSdk.Tool.csproj
@@ -36,6 +36,7 @@
 		<PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
 		<PackageReference Include="Spectre.Console" Version="0.49.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        <PackageReference Include="NuGet.Versioning" Version="6.11.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/AndroidSdk.Tool/JdkDotNetPreferCommand.cs
+++ b/AndroidSdk.Tool/JdkDotNetPreferCommand.cs
@@ -1,0 +1,41 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace AndroidSdk.Tool
+{
+	public class JdkDotNetPreferCommandSettings : CommandSettings
+	{
+		[Description("Java JDK Home/Root Path")]
+		[CommandOption("-h|--home <PATH>")]
+		public string Home { get; set; }
+	}
+	
+	public class JdkDotNetPreferCommand : Command<JdkDotNetPreferCommandSettings>
+	{
+		public override int Execute([NotNull] CommandContext context, [NotNull] JdkDotNetPreferCommandSettings settings)
+		{
+			try
+			{
+				var jdkLocator = new JdkLocator();
+				var jdks = jdkLocator.LocateJdk(settings.Home, returnOnlySpecified: true);
+				var jdk = jdks.FirstOrDefault();
+
+				if (jdk != null)
+				{
+					MonoDroidSdkLocator.UpdatePaths(new MonoDroidSdkLocation(null, javaJdkPath: jdk.Home.FullName));
+					return 0;
+				}
+			}
+			catch (Exception sdkEx)
+			{
+				AnsiConsole.WriteException(sdkEx);
+			}
+
+			return 1;
+		}
+	}
+}

--- a/AndroidSdk.Tool/JdkListCommand.cs
+++ b/AndroidSdk.Tool/JdkListCommand.cs
@@ -1,9 +1,11 @@
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using NuGet.Versioning;
 
 namespace AndroidSdk.Tool
 {
@@ -16,15 +18,19 @@ namespace AndroidSdk.Tool
 		public OutputFormat Format { get; set; }
 
 		[Description("Java JDK Home/Root Path")]
-		[CommandOption("-h|--home")]
+		[CommandOption("-h|--home <HOME>")]
 		public string Home { get; set; }
 
 		[Description("Additional JDK Home Paths to search")]
-		[CommandOption("-p|--path")]
+		[CommandOption("-p|--path <PATH>")]
 		public string[] AdditionalPaths { get; set; }
+		
+		[Description("Filter returned versions based on a NuGet syntax version or version range")]
+		[CommandOption("-v|--version <VERSION>")]
+		public string? VersionRange { get; set; }
 	}
 
-	record JdkInfoOutput(string Version, string Home, string Java, string JavaC, bool DotNetPreferred, bool SetByEnvironmentVariable);
+	record JdkInfoOutput(NuGetVersion Version, string Home, string Java, string JavaC, bool DotNetPreferred, bool SetByEnvironmentVariable);
 
 	public class JdkListCommand : Command<JdkListCommandSettings>
 	{
@@ -32,16 +38,37 @@ namespace AndroidSdk.Tool
 		{
 			try
 			{
+				var supportedJdkVersionRange = new VersionRange(new NuGetVersion(17, 0,0));
+				if (!string.IsNullOrEmpty(settings.VersionRange) && VersionRange.TryParse(settings.VersionRange, out var vr))
+					supportedJdkVersionRange = vr;
+
 				var j = new AndroidSdk.JdkLocator();
 				var jdks = j.LocateJdk(settings.Home, settings.AdditionalPaths);
+				
+				var jdkList = new List<JdkInfoOutput>();
 
-				var jdkList = jdks.Select(j => new JdkInfoOutput(j.Version, j.Home.FullName, j.Java.FullName, j.JavaC.FullName, j.PreferredByDotNet, j.SetByEnvironmentVariable)).ToList();
+				foreach (var jdk in jdks)
+				{
+					if (!NuGetVersion.TryParse(jdk.Version, out var jdkVersion))
+						continue;
 
+					if (!supportedJdkVersionRange.Satisfies(jdkVersion))
+						continue;
+					
+					var jdkInfo = new JdkInfoOutput(jdkVersion, jdk.Home.FullName, jdk.Java.FullName,
+						jdk.JavaC.FullName, jdk.PreferredByDotNet, jdk.SetByEnvironmentVariable);
+					
+					jdkList.Add(jdkInfo);
+				}
+				
+				// Sort by newest first
+				jdkList = jdkList.OrderByDescending(j => j.Version).ToList();
+				
 				OutputHelper.Output<JdkInfoOutput>(
 					jdkList,
 					settings.Format,
 					[ "Version", "Path", "Java", "JavaC", "DotNet Preferred", "From Env Var" ],
-					i => [ i.Version, i.Home, i.Java, i.JavaC, i.SetByEnvironmentVariable.ToString() ]);
+					i => [ i.Version.ToNormalizedString(), i.Home, i.Java, i.JavaC, i.DotNetPreferred.ToString(), i.SetByEnvironmentVariable.ToString() ]);
 			}
 			catch (Exception sdkEx)
 			{

--- a/AndroidSdk.Tool/Program.cs
+++ b/AndroidSdk.Tool/Program.cs
@@ -36,12 +36,20 @@ namespace AndroidSdk.Tool
 					sdkBranch.AddCommand<SdkInfoCommand>("info")
 						.WithDescription("Android SDK Info")
 						.WithExample(new[] { "sdk", "info" });
+					
+					sdkBranch.AddCommand<SdkInfoCommand>("dotnet-prefer")
+						.WithDescription("Sets the DotNet (.NET) preferred SDK location")
+						.WithExample(new[] { "sdk", "dotnet-prefer", "--home /path/to/androidsdk" });
 				});
 
 				config.AddBranch("jdk", jdkBranch => {
 					jdkBranch.AddCommand<JdkListCommand>("list")
 						.WithDescription("Searches for and lists JDK locations")
 						.WithExample([ "jdk", "list" ]);
+					
+					jdkBranch.AddCommand<JdkDotNetPreferCommand>("dotnet-prefer")
+						.WithDescription("Sets the DotNet (.NET) preferred JDK location")
+						.WithExample([ "jdk", "dotnet-prefer", "--home /path/to/jdk" ]);
 				});
 
 				config.AddBranch("device", sdkBranch =>

--- a/AndroidSdk.Tool/SdkDotNetPreferCommand.cs
+++ b/AndroidSdk.Tool/SdkDotNetPreferCommand.cs
@@ -1,0 +1,40 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace AndroidSdk.Tool
+{
+	public class SdkDotNetPreferCommandSettings : CommandSettings
+	{
+		[Description("Android SDK Home Path")]
+		[CommandOption("-h|--home <PATH>")]
+		public string Home { get; set; }
+	}
+	
+	public class SdkDotNetPreferCommand : Command<SdkDotNetPreferCommandSettings>
+	{
+		public override int Execute([NotNull] CommandContext context, [NotNull] SdkDotNetPreferCommandSettings settings)
+		{
+			try
+			{
+				var sdkLocator = new SdkLocator();
+				var sdk = sdkLocator.Locate(settings.Home)?.FirstOrDefault();
+
+				if (sdk != null)
+				{
+					MonoDroidSdkLocator.UpdatePaths(new MonoDroidSdkLocation(sdk.Root.FullName, null));
+					return 0;
+				}
+			}
+			catch (Exception sdkEx)
+			{
+				AnsiConsole.WriteException(sdkEx);
+			}
+
+			return 1;
+		}
+	}
+}

--- a/AndroidSdk/JdkLocator.cs
+++ b/AndroidSdk/JdkLocator.cs
@@ -27,13 +27,33 @@ namespace AndroidSdk
 			return jdks?.Select(j => j.Home)?.ToList() ?? new List<DirectoryInfo>();
 		}
 
-		public IEnumerable<JdkInfo> LocateJdk(string? specificHome = null, params string[]? additionalPossibleDirectories)
+		public IEnumerable<JdkInfo> LocateJdk(string? specificHome = null,
+			params string[]? additionalPossibleDirectories)
+			=> LocateJdk(specificHome, false, additionalPossibleDirectories);
+		
+		public IEnumerable<JdkInfo> LocateJdk(string? specificHome, bool returnOnlySpecified = false, params string[]? additionalPossibleDirectories)
 		{
 			var paths = new List<JdkInfo>();
 
 			if (specificHome != null)
 			{
 				SearchDirectoryForJdks(paths, specificHome, true);
+
+				if (returnOnlySpecified)
+				{
+					// We search additional paths later again if we aren't only returning specified possibilities
+					// Otherwise, we may check these additional paths here first too
+					if (additionalPossibleDirectories != null && additionalPossibleDirectories.Any())
+					{
+						foreach (var d in additionalPossibleDirectories)
+						{
+							SearchDirectoryForJdks(paths, d, true);
+						}
+					}
+
+					// If only returning specified, we should not search any further
+					return paths;
+				}
 			}
 
 			if (IsWindows) {


### PR DESCRIPTION
- Adds `sdk dotnet-prefer --home /path/to/androidsdk` and `jdk dotnet-prefer --home /path/to/jdk` commands to be able to set the .NET preferred Java JDK and Android SDK locations in config files/registry keys that the .NET Android build targets and tasks will prefer when locating these paths.
- Adds a `--version` filter to `jdk list` command that takes a version or version range (in NuGet format) to filter the returned results by