### PR TITLE
Fix some path lookup issues

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,9 +26,15 @@ jobs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
     - name: Install Packages
-      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
+      run: |
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
     - name: Create AVD
-      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
+      run: |
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
     - name: Enabling more cores
       run: |
         ls -la /home/runner

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,13 +27,6 @@ jobs:
         sudo udevadm trigger --name-match=kvm
     - name: Build the project
       run: dotnet build AndroidSdk.Tool
-    # Set ANDROID_AVD_HOME to a consistent location because the AVD manager respects the XDG_CONFIG_HOME
-    # but the emulator does not and fails.
-    - name: Set the ANDROID_AVD_HOME envvar to '~/.android/avd' if it is not already set
-      run: |
-        if [ -z "$ANDROID_AVD_HOME" ]; then
-          echo "ANDROID_AVD_HOME=$HOME/.android/avd" >> $GITHUB_ENV
-        fi
     - name: Print SDK information
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk info
     - name: Install Packages
@@ -43,11 +36,12 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
     - name: Create AVD
       run: |
+        unset XDG_CONFIG_HOME
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
     - name: Enabling more cores
-      run: printf 'hw.cpu.ncore=2\n' >> $ANDROID_AVD_HOME/config.ini
+      run: printf 'hw.cpu.ncore=2\n' >> ~/.android/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -53,4 +53,6 @@ jobs:
     - name: Uninstall an app
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- device uninstall --package com.companyname.mauiapp12345
     - name: Delete AVD
-      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd delete -n test
+      run: |
+        unset XDG_CONFIG_HOME
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd delete -n test

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -47,8 +47,7 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
     - name: Enabling more cores
-      run: |
-        printf 'hw.cpu.ncore=2\n' >> $ANDROID_SDK_HOME/avd/config.ini
+      run: printf 'hw.cpu.ncore=2\n' >> $ANDROID_SDK_HOME/avd/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,6 +27,7 @@ jobs:
         sudo udevadm trigger --name-match=kvm
     - name: Install Packages
       run: |
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk info
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -36,7 +36,6 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
     - name: Create AVD
       run: |
-        env
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,6 +27,13 @@ jobs:
         sudo udevadm trigger --name-match=kvm
     - name: Build the project
       run: dotnet build AndroidSdk.Tool
+    # Set ANDROID_SDK_HOME to a consistent location because the AVD manager respects the XDG_CONFIG_HOME
+    # but the emulator does not and fails.
+    - name: Set the ANDROID_SDK_HOME if it is not set to ~/.android
+      run: |
+        if [ -z "$ANDROID_SDK_HOME" ]; then
+          echo "ANDROID_SDK_HOME=$HOME/.android" >> $GITHUB_ENV
+        fi
     - name: Print SDK information
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk info
     - name: Install Packages
@@ -41,12 +48,7 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
     - name: Enabling more cores
       run: |
-        if [ -n "$XDG_CONFIG_HOME" ]; then
-          DOT_ANDROID_ROOT="$XDG_CONFIG_HOME/.android"
-        else
-          DOT_ANDROID_ROOT="$HOME/.android"
-        fi
-        printf 'hw.cpu.ncore=2\n' >> $DOT_ANDROID_ROOT/avd/config.ini
+        printf 'hw.cpu.ncore=2\n' >> $ANDROID_SDK_HOME/avd/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,9 +27,10 @@ jobs:
         sudo udevadm trigger --name-match=kvm
     - name: Build the project
       run: dotnet build AndroidSdk.Tool
+    - name: Print SDK information
+      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk info
     - name: Install Packages
       run: |
-        dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk info
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
@@ -42,6 +43,9 @@ jobs:
     - name: Enabling more cores
       run: |
         ls -la /home/runner
+        ls -la /home/runner/.config
+        ls -la /home/runner/.config/.android
+        ls -la /home/runner/.config/.android/avd
         printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,6 +25,8 @@ jobs:
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
+    - name: Build the project
+      run: dotnet build AndroidSdk.Tool
     - name: Install Packages
       run: |
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk info

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -30,7 +30,11 @@ jobs:
     - name: Create AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
     - name: Enabling more cores
-      run: printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
+      run: |
+        ls -l /home/runner/
+        ls -l /home/runner/.android/
+        ls -l /home/runner/avd/
+        printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -36,14 +36,14 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
     - name: Create AVD
       run: |
+        unset XDG_CONFIG_HOME
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
-        ANDROID_AVD_HOME=$HOME/.android/avd dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
     - name: Enabling more cores
       run: printf 'hw.cpu.ncore=2\n' >> $HOME/.android/avd/config.ini
     - name: Start AVD
-      run: |
-        ANDROID_AVD_HOME=$HOME/.android/avd dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
+      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted
       run: |
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- device list
@@ -54,4 +54,5 @@ jobs:
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- device uninstall --package com.companyname.mauiapp12345
     - name: Delete AVD
       run: |
-        ANDROID_AVD_HOME=$HOME/.android/avd dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd delete -n test
+        unset XDG_CONFIG_HOME
+        dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd delete -n test

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         ls -l /home/runner/
         ls -l /home/runner/.android/
-        ls -l /home/runner/avd/
+        ls -l /home/runner/.android/avd/
         printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -29,8 +29,10 @@ jobs:
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
     - name: Create AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
-    #- name: Enabling more cores
-    #  run: printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
+    - name: Enabling more cores
+      run: |
+        ls -la /home/runner
+        printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -35,6 +35,7 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
     - name: Create AVD
       run: |
+        env
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -29,7 +29,7 @@ jobs:
       run: dotnet build AndroidSdk.Tool
     # Set ANDROID_SDK_HOME to a consistent location because the AVD manager respects the XDG_CONFIG_HOME
     # but the emulator does not and fails.
-    - name: Set the ANDROID_SDK_HOME if it is not set to ~/.android
+    - name: Set the ANDROID_SDK_HOME envvar to '~/.android' if it is not already set
       run: |
         if [ -z "$ANDROID_SDK_HOME" ]; then
           echo "ANDROID_SDK_HOME=$HOME/.android" >> $GITHUB_ENV

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -42,11 +42,12 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
     - name: Enabling more cores
       run: |
-        ls -la /home/runner
-        ls -la /home/runner/.config
-        ls -la /home/runner/.config/.android
-        ls -la /home/runner/.config/.android/avd
-        printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
+        if [ -n "$XDG_CONFIG_HOME" ]; then
+          DOT_ANDROID_ROOT="$XDG_CONFIG_HOME/.android"
+        else
+          DOT_ANDROID_ROOT="$HOME/.android"
+        fi
+        printf 'hw.cpu.ncore=2\n' >> $DOT_ANDROID_ROOT/avd/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -29,12 +29,8 @@ jobs:
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk install -p "emulator" -p "platform-tools" -p "platforms;android-34" -p "system-images;android-34;google_apis;x86_64"
     - name: Create AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
-    - name: Enabling more cores
-      run: |
-        ls -l /home/runner/
-        ls -l /home/runner/.android/
-        ls -l /home/runner/.android/avd/
-        printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
+    #- name: Enabling more cores
+    #  run: printf 'hw.cpu.ncore=2\n' >> /home/runner/.android/avd/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -36,14 +36,14 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk list --installed
     - name: Create AVD
       run: |
-        unset XDG_CONFIG_HOME
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
-        dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
+        ANDROID_AVD_HOME=$HOME/.android/avd dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
     - name: Enabling more cores
-      run: printf 'hw.cpu.ncore=2\n' >> ~/.android/config.ini
+      run: printf 'hw.cpu.ncore=2\n' >> $HOME/.android/avd/config.ini
     - name: Start AVD
-      run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
+      run: |
+        ANDROID_AVD_HOME=$HOME/.android/avd dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted
       run: |
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- device list
@@ -54,5 +54,4 @@ jobs:
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- device uninstall --package com.companyname.mauiapp12345
     - name: Delete AVD
       run: |
-        unset XDG_CONFIG_HOME
-        dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd delete -n test
+        ANDROID_AVD_HOME=$HOME/.android/avd dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd delete -n test

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,12 +27,12 @@ jobs:
         sudo udevadm trigger --name-match=kvm
     - name: Build the project
       run: dotnet build AndroidSdk.Tool
-    # Set ANDROID_SDK_HOME to a consistent location because the AVD manager respects the XDG_CONFIG_HOME
+    # Set ANDROID_AVD_HOME to a consistent location because the AVD manager respects the XDG_CONFIG_HOME
     # but the emulator does not and fails.
-    - name: Set the ANDROID_SDK_HOME envvar to '~/.android' if it is not already set
+    - name: Set the ANDROID_AVD_HOME envvar to '~/.android/avd' if it is not already set
       run: |
-        if [ -z "$ANDROID_SDK_HOME" ]; then
-          echo "ANDROID_SDK_HOME=$HOME/.android" >> $GITHUB_ENV
+        if [ -z "$ANDROID_AVD_HOME" ]; then
+          echo "ANDROID_AVD_HOME=$HOME/.android/avd" >> $GITHUB_ENV
         fi
     - name: Print SDK information
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- sdk info
@@ -47,7 +47,7 @@ jobs:
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd create -f -n "test" -a "google_apis/x86_64" -s "system-images;android-34;google_apis;x86_64"
         dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd list
     - name: Enabling more cores
-      run: printf 'hw.cpu.ncore=2\n' >> $ANDROID_SDK_HOME/avd/config.ini
+      run: printf 'hw.cpu.ncore=2\n' >> $ANDROID_AVD_HOME/config.ini
     - name: Start AVD
       run: dotnet run --framework net8.0 --project AndroidSdk.Tool -- avd start -p 5554 -n test --no-window --gpu swiftshader_indirect --no-snapshot --no-audio --no-boot-anim --wait
     - name: Prove that it booted

--- a/AndroidSdk.Tool/OutputHelper.cs
+++ b/AndroidSdk.Tool/OutputHelper.cs
@@ -70,7 +70,7 @@ namespace AndroidSdk.Tool
 			for (int i = 0; i < properties.Length; i++)
 			{
 				var name = properties[i];
-				var val = values[i];
+				var val = values[i] ?? "";
 
 				table.AddRow(name, val);
 			}

--- a/AndroidSdk/AvdManager/AvdManager.cs
+++ b/AndroidSdk/AvdManager/AvdManager.cs
@@ -187,7 +187,7 @@ namespace AndroidSdk
 			return r;
 		}
 
-		static Regex rxListAvds = new Regex(@"\s+Name:\s+(?<name>[^\n]+)\s+Device:\s+(?<device>[^\n]+)\s+Path:\s+(?<path>[^\n]+)\s+Target:\s+(?<target>[^\n]+)\s+Based on:\s+(?<basedon>[^\n]+)", RegexOptions.Compiled | RegexOptions.Multiline);
+		static Regex rxListAvds = new Regex(@"\s+Name:\s+(?<name>[^\n]+)(\s+Device:\s+(?<device>[^\n]+))?\s+Path:\s+(?<path>[^\n]+)\s+Target:\s+(?<target>[^\n]+)\s+Based on:\s+(?<basedon>[^\n]+)", RegexOptions.Compiled | RegexOptions.Multiline);
 		public IEnumerable<Avd> ListAvds()
 		{
 			var r = new List<Avd>();

--- a/AndroidSdk/JdkLocator.cs
+++ b/AndroidSdk/JdkLocator.cs
@@ -129,7 +129,7 @@ namespace AndroidSdk
 			}
 
 
-			var environmentPaths = Environment.GetEnvironmentVariable("PATH")?.Split(';') ?? Array.Empty<string>();
+			var environmentPaths = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? Array.Empty<string>();
 
 			foreach (var envPath in environmentPaths)
 			{


### PR DESCRIPTION
### Description

This PR fixes 2 main issues:

1. When a machine has `XDG_CONFIG_HOME` set, it will create the AVD images under `$XDG_CONFIG_HOME/.android/avd` instead of `~/.android/avd`. This will lead to the tool not being able to find the AVDs.  
   > I was able to reproduce this locally as well for some time, but then my laptop went to sleep and now I can't. But, with the changes to search more locations, listing the AVDs now works.

2. This PR also fixes the issue where the AVD list command was not handling the case where there was missing information in the output.