### PR TITLE
Handle SIG INT/QUIT/TERM in Emulator AVD Start command

### DIFF
--- a/AndroidSdk.Tool/CancellableAsyncCommand.cs
+++ b/AndroidSdk.Tool/CancellableAsyncCommand.cs
@@ -1,0 +1,30 @@
+﻿using Spectre.Console.Cli;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AndroidSdk.Tool;
+
+public abstract class CancellableAsyncCommand<TSettings> : AsyncCommand<TSettings>
+	where TSettings : CommandSettings
+{
+	public abstract Task<int> ExecuteAsync(CommandContext context, TSettings settings, CancellationToken cancellation);
+
+	public override async Task<int> ExecuteAsync(CommandContext context, TSettings settings)
+	{
+		using var cancellationSource = new CancellationTokenSource();
+
+		using var sigInt = PosixSignalRegistration.Create(PosixSignal.SIGINT, onSignal);
+		using var sigQuit = PosixSignalRegistration.Create(PosixSignal.SIGQUIT, onSignal);
+		using var sigTerm = PosixSignalRegistration.Create(PosixSignal.SIGTERM, onSignal);
+
+		var cancellable = ExecuteAsync(context, settings, cancellationSource.Token);
+		return await cancellable;
+
+		void onSignal(PosixSignalContext context)
+		{
+			context.Cancel = true;
+			cancellationSource.Cancel();
+		}
+	}
+}

--- a/AndroidSdk/Emulator/Emulator.cs
+++ b/AndroidSdk/Emulator/Emulator.cs
@@ -216,8 +216,8 @@ namespace AndroidSdk
 			{
 				result = process.WaitForExit();
 
-				if (result.ExitCode != 0)
-					throw new SdkToolFailedExitException("avdmanager", result.ExitCode, result.StandardError, result.StandardOutput);
+				if (result.ExitCode != 0 && result.ExitCode != 1)
+					throw new SdkToolFailedExitException("emulator", result.ExitCode, result.StandardError, result.StandardOutput);
 
 				return result.ExitCode;
 			}


### PR DESCRIPTION
Now, especially if you are waiting for the emulator to stop, you can use console commands/signals to shutdown the running emulator a bit more gracefully.