### PR TITLE
Fix JdkLocator Mac Catalyst platform detection and JVM directory search

### DIFF
--- a/AndroidSdk/JdkLocator.cs
+++ b/AndroidSdk/JdkLocator.cs
@@ -18,7 +18,11 @@ namespace AndroidSdk
 			=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
 		protected bool IsMac
-			=> RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+			=> RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+#if NET6_0_OR_GREATER
+			|| OperatingSystem.IsMacCatalyst()
+#endif
+			;
 
 		protected bool IsLinux
 			=> RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
@@ -108,11 +112,11 @@ namespace AndroidSdk
 					{
 						var javaVmJdkDirs = Directory.EnumerateDirectories(javaVmDir, "*.jdk", SearchOption.TopDirectoryOnly);
 						foreach (var javaVmJdkDir in javaVmJdkDirs)
-							SearchDirectoryForJdks(paths, javaVmDir, true);
+							SearchDirectoryForJdks(paths, javaVmJdkDir, true);
 
 						javaVmJdkDirs = Directory.EnumerateDirectories(javaVmDir, "jdk-*", SearchOption.TopDirectoryOnly);
-						 foreach (var javaVmJdkDir in javaVmJdkDirs)
-							SearchDirectoryForJdks(paths, javaVmDir, true);
+						foreach (var javaVmJdkDir in javaVmJdkDirs)
+							SearchDirectoryForJdks(paths, javaVmJdkDir, true);
 					}
 				}
 				catch


### PR DESCRIPTION
## Problem

`JdkLocator.IsMac` uses `RuntimeInformation.IsOSPlatform(OSPlatform.OSX)` which returns `false` when running inside a Mac Catalyst app. This causes the entire Mac JDK search block to be skipped — including `/Library/Java/JavaVirtualMachines/` where Microsoft OpenJDK is installed (whether via `brew install --cask microsoft-openjdk@21` or the .pkg installer directly).

The only fallback paths that still run are `JAVA_HOME`, `JDK_HOME`, and `PATH` environment variables, which are typically not set for cask-installed JDKs.

Related: https://github.com/Redth/MAUI.Sherpa/issues/38

## Fix

1. **Mac Catalyst platform detection**: `IsMac` now also checks `OperatingSystem.IsMacCatalyst()` on .NET 6+ via `#if NET6_0_OR_GREATER`. This ensures Mac-specific JDK paths are searched when the library is consumed by a Mac Catalyst app.

2. **JVM directory search bug**: Fixed the `/Library/Java/JavaVirtualMachines/` enumeration loop where `SearchDirectoryForJdks` was called with the parent `javaVmDir` instead of the matched `javaVmJdkDir`. While the recursive search still found `javac`, it was redundantly searching the entire parent directory on every loop iteration instead of the specific JDK directory.