### PR TITLE
Add Android\openjdk to JDK search paths on Windows

### DIFF
--- a/AndroidSdk/JdkLocator.cs
+++ b/AndroidSdk/JdkLocator.cs
@@ -82,6 +82,10 @@ namespace AndroidSdk
 				SearchDirectoryForJdks(paths,
 					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Android", "Jdk"), true);
 
+				// Android OpenJDK installed by Android Studio or MAUI workload
+				SearchDirectoryForJdks(paths,
+					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Android", "openjdk"), true);
+
 				var pfmsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft");
 
 				try


### PR DESCRIPTION
Android Studio and the .NET MAUI workload install the OpenJDK to `Program Files\Android\openjdk\jdk-<version>` on Windows. The existing JdkLocator search checks `Android\Jdk` but misses these `Android\openjdk` installations.

This adds that directory to the Windows JDK search paths, right next to the existing `Android\Jdk` search.

**Context:** Discovered while getting [MAUI Sherpa](https://github.com/Redth/MAUI.Sherpa) running on Windows — the Doctor page and SdkManager couldn't find the JDK installed at `C:\Program Files\Android\openjdk\jdk-21.0.8`.