### PR TITLE
Improve emulator lifecycle reliability (start, boot, and stop)

### DIFF
--- a/AndroidSdk.Tests/Helpers/EmulatorTestsBase.cs
+++ b/AndroidSdk.Tests/Helpers/EmulatorTestsBase.cs
@@ -64,10 +64,19 @@ public abstract class EmulatorTestsBase(ITestOutputHelper outputHelper, AndroidS
 			sink = messageSink;
 			avdHomeScope = new AvdHomeScope(messageSink, $"{nameof(EmulatorTestsBase)}.{nameof(AvdCreateFixture)}.{Guid.NewGuid():N}");
 
-			sink.OnMessage(new DiagnosticMessage($"Installing system image {TestAvdPackageId} for emulator tests..."));
-			var installOk = sdk.SdkManager.Install(TestAvdPackageId);
-			Assert.True(installOk);
-			sink.OnMessage(new DiagnosticMessage("Installed system image."));
+			sink.OnMessage(new DiagnosticMessage($"Checking if system image {TestAvdPackageId} is installed..."));
+			var installedList = sdk.SdkManager.List();
+			if (!installedList.InstalledPackages.Any(p => p.Path == TestAvdPackageId))
+			{
+				sink.OnMessage(new DiagnosticMessage($"Installing system image {TestAvdPackageId} for emulator tests..."));
+				var installOk = sdk.SdkManager.Install(TestAvdPackageId);
+				Assert.True(installOk);
+				sink.OnMessage(new DiagnosticMessage("Installed system image."));
+			}
+			else
+			{
+				sink.OnMessage(new DiagnosticMessage("System image already installed. Skipping download."));
+			}
 
 			sink.OnMessage(new DiagnosticMessage("Asserting system image is installed..."));
 			var list = sdk.SdkManager.List();


### PR DESCRIPTION
## Why this change matters
Starting and managing emulators in automation can fail in subtle ways (startup timing, serial discovery races, and shutdown handling). This PR improves lifecycle reliability so emulator orchestration is more robust.

## What’s included
It adds clearer lifecycle helpers for stop/boot flows, improves serial discovery and timeout behavior, and hardens transient error handling. It also includes fixture-side setup optimization so emulator tests avoid unnecessary system-image installs when already present.

## Validation
- `dotnet build --configuration Release`
- `dotnet test AndroidSdk.Tests/AndroidSdk.Tests.csproj --configuration Release --filter "FullyQualifiedName~Emulator_Tests"`
