### PR TITLE
Make package parsing resilient when install paths contain '='

### DIFF
--- a/AndroidSdk.Tests/PackageManager_Tests.cs
+++ b/AndroidSdk.Tests/PackageManager_Tests.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System.Linq;
+using Xunit;
+
+namespace AndroidSdk.Tests;
+
+public class PackageManager_Tests
+{
+	[Theory]
+	[InlineData("package:/data/app/~~wMmr-oLQ7RWpEYgnSyrqBQ==/com.companyname.TestApp-u2_pATr4m8RzW-4W-rLafw==/base.apk=com.companyname.TestApp installer=com.android.shell", "com.android.shell", "u2_pATr4m8RzW-4W-rLafw==")]
+	[InlineData("package:/data/app/com.companyname.TestApp-plain/base.apk=com.companyname.TestApp installer=com.android.vending", "com.android.vending", "com.companyname.TestApp-plain")]
+	public void ParsePackageListOutputHandlesInstallPathsWithAndWithoutEquals(string line, string installer, string pathFragment)
+	{
+		var lines = new[] { line };
+
+		var packages = PackageManager.ParsePackageListOutput(lines);
+
+		var package = Assert.Single(packages);
+		Assert.Equal("com.companyname.TestApp", package.PackageName);
+		Assert.Equal(installer, package.Installer);
+		Assert.Contains(pathFragment, package.InstallPath.FullName);
+	}
+
+	[Fact]
+	public void ParsePackageListOutputHandlesEmptyInstaller()
+	{
+		var lines = new[]
+		{
+			"package:/data/app/com.companyname.NoInstaller/base.apk=com.companyname.NoInstaller installer="
+		};
+
+		var package = Assert.Single(PackageManager.ParsePackageListOutput(lines));
+		Assert.Equal("com.companyname.NoInstaller", package.PackageName);
+		Assert.Equal(string.Empty, package.Installer);
+	}
+
+	[Fact]
+	public void ParsePackageListOutputIgnoresNonMatchingLines()
+	{
+		var lines = new[]
+		{
+			"unexpected output",
+			"package: missing bits"
+		};
+
+		Assert.Empty(PackageManager.ParsePackageListOutput(lines).ToList());
+	}
+}


### PR DESCRIPTION
## Why this change matters
Some Android package listings include `=` inside the install path. When that happens, our previous parsing could split the line incorrectly and return incomplete package metadata.

## What’s included
This PR updates the parsing logic so package lines are interpreted correctly even when paths contain `=`. It also adds targeted unit tests around these edge cases (plus non-matching input cases) to keep this behavior stable.

## Validation
- `dotnet build --configuration Release`
- `dotnet test AndroidSdk.Tests/AndroidSdk.Tests.csproj --configuration Release --filter "FullyQualifiedName~PackageManager_Tests"`
