### PR TITLE
ci: validate full app lifecycle in emulator workflow (phase 2)

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -82,6 +82,81 @@ jobs:
         echo "✅ Emulator is running and device commands are healthy"
       env:
         ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/avd-start-validate.log
+    - name: Do Install test app
+      run: dotnet run --framework net9.0 --project AndroidSdk.Tool -- device install --package AndroidSdk.Tests/testdata/com.companyname.mauiapp12345-Signed.apk
+      env:
+        ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/device-install-do.log
+    - name: Validate Install test app
+      run: |
+        PACKAGE_NAME="com.companyname.mauiapp12345"
+        PACKAGES=$(dotnet run --no-launch-profile --framework net9.0 --project AndroidSdk.Tool -- device packages --format json | tail -n 1)
+        echo "$PACKAGES" > artifacts/packages-after-install.json
+        if ! echo "$PACKAGES" | jq -e --arg pkg "$PACKAGE_NAME" '.[] | select(.packageName == $pkg)' > /dev/null 2>&1; then
+          echo "❌ Package '$PACKAGE_NAME' missing after install"
+          cat artifacts/device-install-do.log
+          exit 1
+        fi
+        echo "✅ Package '$PACKAGE_NAME' installed successfully"
+      env:
+        ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/device-install-validate.log
+    - name: Do Launch test app
+      run: dotnet run --framework net9.0 --project AndroidSdk.Tool -- device launch --package com.companyname.mauiapp12345
+      env:
+        ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/device-launch-do.log
+    - name: Validate Launch test app
+      run: |
+        if ! grep -qi "Events injected" artifacts/device-launch-do.log; then
+          echo "❌ Launch validation failed: expected strict 'Events injected' marker"
+          cat artifacts/device-launch-do.log
+          exit 1
+        fi
+        echo "✅ Launch validation passed with strict 'Events injected' marker"
+      env:
+        ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/device-launch-validate.log
+    - name: Do Capture logcat
+      run: dotnet run --framework net9.0 --project AndroidSdk.Tool -- device logcat --output artifacts/device-logcat.txt
+      env:
+        ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/device-logcat-do.log
+    - name: Validate launch marker in logcat
+      timeout-minutes: 10
+      run: |
+        FOUND=0
+        for i in $(seq 1 30); do
+          dotnet run --framework net9.0 --project AndroidSdk.Tool -- device logcat --output artifacts/device-logcat.txt
+          if grep -q "E2E_APP_STARTED_SUCCESSFULLY" artifacts/device-logcat.txt; then
+            echo "✅ Marker found on attempt $i"
+            FOUND=1
+            break
+          fi
+          echo "Attempt $i/30 - marker not found yet, waiting 5s..."
+          sleep 5
+        done
+        if [ "$FOUND" -ne 1 ]; then
+          echo "❌ Marker not found in logcat after 30 attempts"
+          cat artifacts/device-logcat.txt
+          exit 1
+        fi
+      env:
+        ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/device-logcat-validate.log
+    - name: Do Uninstall test app
+      if: always()
+      run: dotnet run --framework net9.0 --project AndroidSdk.Tool -- device uninstall --package com.companyname.mauiapp12345
+      env:
+        ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/device-uninstall-do.log
+    - name: Validate Uninstall test app
+      if: always()
+      run: |
+        PACKAGE_NAME="com.companyname.mauiapp12345"
+        PACKAGES=$(dotnet run --no-launch-profile --framework net9.0 --project AndroidSdk.Tool -- device packages --format json | tail -n 1)
+        echo "$PACKAGES" > artifacts/packages-after-uninstall.json
+        if echo "$PACKAGES" | jq -e --arg pkg "$PACKAGE_NAME" '.[] | select(.packageName == $pkg)' > /dev/null 2>&1; then
+          echo "❌ Package '$PACKAGE_NAME' still present after uninstall"
+          cat artifacts/device-uninstall-do.log
+          exit 1
+        fi
+        echo "✅ Package '$PACKAGE_NAME' uninstalled successfully"
+      env:
+        ANDROID_TOOL_PROCESS_RUNNER_LOG_PATH: artifacts/device-uninstall-validate.log
     - name: Delete AVD
       if: always()
       run: dotnet run --framework net9.0 --project AndroidSdk.Tool -- avd delete -n test --force


### PR DESCRIPTION
This PR is the phase-2 follow-up to the emulator workflow rollout. Phase 1 established reliable Ubuntu smoke checks; this phase adds full app-lifecycle validation so CI verifies not just emulator boot, but real command behavior end-to-end.

### Why this matters
Community contributors usually debug failures at the app-lifecycle boundary (install, launch, logs, cleanup), not just emulator startup. By validating those paths directly in CI, regressions are easier to detect and easier to reason about.

### What this adds
`run.yml` now validates a complete app flow after emulator boot:
- install test APK and verify package presence,
- launch app and require strict `Events injected` launch signal,
- capture logcat and validate `E2E_APP_STARTED_SUCCESSFULLY` marker with retry loop,
- uninstall app and verify package removal.

### Reliability details
- JSON command parsing continues to use `--no-launch-profile` + `tail -n 1` to avoid noisy preamble output.
- Uninstall validation runs in `always()` cleanup path so CI leaves cleaner state even after earlier failures.
- Logs and package snapshots are preserved in artifacts for triage.

### Scope
- Workflow-only change (`.github/workflows/run.yml`).
- No net10 migration, no macOS matrix changes, no unrelated command/runtime changes.

### Validation run
```bash
dotnet build --configuration Release
```
Result: build passed locally.
