### PR TITLE
Modernize project targets to include .NET 10 across library, tool, and tests

### DIFF
--- a/AndroidRepository/AndroidRepository.csproj
+++ b/AndroidRepository/AndroidRepository.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>

--- a/AndroidSdk.Adbd.Tests/AndroidSdk.Adbd.Tests.csproj
+++ b/AndroidSdk.Adbd.Tests/AndroidSdk.Adbd.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <DefineConstants Condition="'$(CI)' == 'true'">$(DefineConstants);IS_ON_CI</DefineConstants>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/AndroidSdk.Tests/AndroidSdk.Tests.csproj
+++ b/AndroidSdk.Tests/AndroidSdk.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <DefineConstants Condition="'$(CI)' == 'true'">$(DefineConstants);IS_ON_CI</DefineConstants>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/AndroidSdk.Tool/AndroidSdk.Tool.csproj
+++ b/AndroidSdk.Tool/AndroidSdk.Tool.csproj
@@ -4,7 +4,7 @@
 		<OutputType>Exe</OutputType>
 		<AssemblyName>android</AssemblyName>
 		<PackAsTool>true</PackAsTool>
-		<TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		<ToolCommandName>android</ToolCommandName>
 		<RollForward>Major</RollForward>
 		<LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Why
This is the first of the two planned follow-up PRs from the old #56 split backlog. It brings in the deferred .NET 10 target-framework modernization as a small, mechanical change set so reviewers can evaluate framework compatibility independently from workflow changes.

## What changed
- Added `net10.0` to `AndroidRepository/AndroidRepository.csproj` target frameworks
- Added `net10.0` to `AndroidSdk.Tool/AndroidSdk.Tool.csproj` target frameworks
- Updated `AndroidSdk.Adbd.Tests/AndroidSdk.Adbd.Tests.csproj` target framework to `net10.0`
- Updated `AndroidSdk.Tests/AndroidSdk.Tests.csproj` target framework to `net10.0`

## What is intentionally out of scope
- No workflow changes (those are in PR 2 of 2)
- No runtime behavior changes
- No API36/logcat fallback pivots

## Validation
- ✅ `dotnet build --configuration Release`
- ⚠️ `dotnet test AndroidSdk.Adbd.Tests/AndroidSdk.Adbd.Tests.csproj --configuration Release` (fails with existing environment-dependent `Adbd_Tests.GetShellProps` issue)
- ⚠️ `dotnet test AndroidSdk.Tests/AndroidSdk.Tests.csproj --configuration Release` (fails with existing emulator-dependent `EmulatorOperations_Tests.LaunchStaticAppLaunches` issue)

Given the scoped nature of this PR (TFM declarations only), these test failures appear unrelated to this change set.
